### PR TITLE
Inline acorn.getLineInfo to avoid quadratic time slowdown

### DIFF
--- a/lib/parseJson.js
+++ b/lib/parseJson.js
@@ -47,6 +47,26 @@ function fixTokens({code, ast}) {
     // Remove the first '(' and the last two tokens ')', ';'
     ast.tokens = ast.tokens.slice(1, ast.tokens.length - 2);
 
+    const lineBreak = /\r\n?|\n|\u2028|\u2029/
+    const lineBreakG = new RegExp(lineBreak.source, "g")
+    let line = 1, cur = 0;
+
+    // Inline version of acorn.getLineInfo that uses
+    // the same line/cur counters to avoid a quadratic time
+    // search. The only works because the token list is sorted
+    // and non-overlapping.
+    function getLineInfo(offset) {
+        while (true) {
+            lineBreakG.lastIndex = cur
+            let match = lineBreakG.exec(code)
+            if (match && match.index < offset) {
+                ++line
+                cur = match.index + match[0].length
+            } else {
+                return new acorn.Position(line, offset - cur)
+            }
+        }
+    }
     // Fix the location of the tokens
     ast.tokens.forEach(token => {
         token.start = token.start - 1;
@@ -54,8 +74,8 @@ function fixTokens({code, ast}) {
         token.range = [token.start, token.end];
 
         if (token.loc) {
-            token.loc.start = acorn.getLineInfo(code, token.start);
-            token.loc.end = acorn.getLineInfo(code, token.end);
+            token.loc.start = getLineInfo(token.start);
+            token.loc.end = getLineInfo(token.end);
         }
     });
 }


### PR DESCRIPTION
Partially addresses #12
