### PR TITLE
Simplify location fixer to only fix line 1

### DIFF
--- a/lib/parseJson.js
+++ b/lib/parseJson.js
@@ -1,17 +1,15 @@
 const espree = require('espree');
 const evk = require('eslint-visitor-keys');
-const acorn = require('acorn');
 
 function parseJson(code, options) {
     const validCode = `(${code});`;
 
     try {
         const ast = espree.parse(validCode, options);
-        const context = {code, ast};
 
-        fixProgram(context);
-        fixTokens(context);
-        fixNodes(context);
+        fixProgram(ast);
+        fixTokens(ast);
+        fixNodes(ast);
 
         return {
             ast,
@@ -35,7 +33,7 @@ function parseJson(code, options) {
     }
 }
 
-function fixProgram({ast}) {
+function fixProgram(ast) {
     ast.end = ast.end - 3;
     ast.range[1] = ast.end
 
@@ -43,25 +41,16 @@ function fixProgram({ast}) {
     ast.body[0] = ast.body[0].expression;
 }
 
-function fixTokens({code, ast}) {
+function fixTokens(ast) {
     // Remove the first '(' and the last two tokens ')', ';'
     ast.tokens = ast.tokens.slice(1, ast.tokens.length - 2);
 
     // Fix the location of the tokens
-    ast.tokens.forEach(token => {
-        token.start = token.start - 1;
-        token.end = token.end - 1;
-        token.range = [token.start, token.end];
-
-        if (token.loc) {
-            token.loc.start = acorn.getLineInfo(code, token.start);
-            token.loc.end = acorn.getLineInfo(code, token.end);
-        }
-    });
+    ast.tokens.forEach(fixLocation);
 }
 
-function fixNodes({code, ast}) {
-    traverseAst(ast.body[0], node => fixLocation({node, code}));
+function fixNodes(ast) {
+    traverseAst(ast.body[0], node => fixLocation(node));
 }
 
 function traverseAst(node, callback) {
@@ -82,7 +71,16 @@ function traverseAst(node, callback) {
     }
 }
 
-function fixLocation({node, code}) {
+function fixPosition(loc) {
+    if (loc.line === 1 && !loc.fixed) {
+        loc.column--;
+        // Position objects can be shared between
+        // ast.tokens & ast.nodes, so mark as fixed
+        loc.fixed = true;
+    }
+}
+
+function fixLocation(node) {
     if (node.start) {
         node.start = node.start - 1;
         node.range[0] = node.start;
@@ -94,8 +92,8 @@ function fixLocation({node, code}) {
     }
 
     if (node.loc) {
-        node.loc.start = acorn.getLineInfo(code, node.start);
-        node.loc.end = acorn.getLineInfo(code, node.end);
+        fixPosition(node.loc.start);
+        fixPosition(node.loc.end);
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     },
     "homepage": "https://github.com/zeitport/eslint-plugin-json-es#readme",
     "dependencies": {
-        "acorn": "^7.4.1",
         "eslint-visitor-keys": "^1.3.0",
         "espree": "^7.3.1"
     },

--- a/test/lib/parseJson.test.js
+++ b/test/lib/parseJson.test.js
@@ -23,6 +23,18 @@ test('parseJson returns AST', () => {
     expect(parseObject.ast).toBeTruthy();
 });
 
+test('parseJson fixes token locations', () => {
+    // Given
+    const code = createJson();
+
+    // When
+    const parseObject = parseJson(code, parserOptions);
+    const tokenSummary = parseObject.ast.tokens.map(nodeLocSummary);
+
+    // Then
+    expect(tokenSummary).toMatchObject(getExpectedTokenSummary());
+});
+
 test('parseJson with invalid code throws error', () => {
     // Given
     const code = `{`;
@@ -54,4 +66,56 @@ function createJson() {
     };
 
     return JSON.stringify(data, null, 4);
+}
+
+function nodeLocSummary(node) {
+    return {
+        start: {
+            line: node.loc.start.line,
+            column: node.loc.start.column
+        },
+        end: {
+            line: node.loc.end.line,
+            column: node.loc.end.column
+        }
+    }
+}
+
+function getExpectedTokenSummary() {
+    return [
+        { start: { line: 1, column: 0 }, end: { line: 1, column: 1 } },
+        { start: { line: 2, column: 4 }, end: { line: 2, column: 13 } },
+        { start: { line: 2, column: 13 }, end: { line: 2, column: 14 } },
+        { start: { line: 2, column: 15 }, end: { line: 2, column: 16 } },
+        { start: { line: 3, column: 8 }, end: { line: 3, column: 9 } },
+        { start: { line: 4, column: 12 }, end: { line: 4, column: 18 } },
+        { start: { line: 4, column: 18 }, end: { line: 4, column: 19 } },
+        { start: { line: 4, column: 20 }, end: { line: 4, column: 26 } },
+        { start: { line: 4, column: 26 }, end: { line: 4, column: 27 } },
+        { start: { line: 5, column: 12 }, end: { line: 5, column: 19 } },
+        { start: { line: 5, column: 19 }, end: { line: 5, column: 20 } },
+        { start: { line: 5, column: 21 }, end: { line: 5, column: 26 } },
+        { start: { line: 6, column: 8 }, end: { line: 6, column: 9 } },
+        { start: { line: 6, column: 9 }, end: { line: 6, column: 10 } },
+        { start: { line: 7, column: 8 }, end: { line: 7, column: 9 } },
+        { start: { line: 8, column: 12 }, end: { line: 8, column: 18 } },
+        { start: { line: 8, column: 18 }, end: { line: 8, column: 19 } },
+        { start: { line: 8, column: 20 }, end: { line: 8, column: 27 } },
+        { start: { line: 8, column: 27 }, end: { line: 8, column: 28 } },
+        { start: { line: 9, column: 12 }, end: { line: 9, column: 19 } },
+        { start: { line: 9, column: 19 }, end: { line: 9, column: 20 } },
+        { start: { line: 9, column: 21 }, end: { line: 9, column: 22 } },
+        { start: { line: 9, column: 22 }, end: { line: 9, column: 23 } },
+        { start: { line: 10, column: 12 }, end: { line: 10, column: 19 } },
+        { start: { line: 10, column: 19 }, end: { line: 10, column: 20 } },
+        { start: { line: 10, column: 21 }, end: { line: 10, column: 22 } },
+        { start: { line: 10, column: 22 }, end: { line: 10, column: 23 } },
+        { start: { line: 10, column: 23 }, end: { line: 10, column: 24 } },
+        { start: { line: 11, column: 12 }, end: { line: 11, column: 23 } },
+        { start: { line: 11, column: 23 }, end: { line: 11, column: 24 } },
+        { start: { line: 11, column: 25 }, end: { line: 11, column: 29 } },
+        { start: { line: 12, column: 8 }, end: { line: 12, column: 9 } },
+        { start: { line: 13, column: 4 }, end: { line: 13, column: 5 } },
+        { start: { line: 14, column: 0 }, end: { line: 14, column: 1 } }
+    ];
 }


### PR DESCRIPTION
As positions objects are shared between the
token list and the node tree, mark fixed positions
so they don't get fixed twice.
﻿
Also adds test for token locations.

Fixes #12
